### PR TITLE
Ace Jump Word mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ TextMate and Emacs goodies for Xcode.
 ## What is it?
 It's a Xcode plugin provides some handy TextMate and Emacs actions.
 
-###Selecting actions demo:
+###XMate actions in Edit menu:
 
-![image](http://i.minus.com/i9B2FwGwiUJ8F.gif)
+![image](http://shrani.si/f/1e/aO/YOG53s9/xmateeditmenu.png)
 
 ###Emacs Ace Jump mode demo:
 
-![image](http://i.minus.com/ibzQzA079MFYWc.gif)
+![image](http://shrani.si/f/2W/4x/111moo/xmateacejump.gif)
 
 ## Requirement
-Xcode5.1 or above, including Xcode 6
+Xcode 5.1 or above
 
 ## Installation
 
 ### Build It Yourself
-1. Make sure the file path of Xcode5.1 is `/Applications/Xcode.app`, because some Xcode frameworks need to be linked from the Xcode app itself.
+1. Make sure the file path of Xcode is `/Applications/Xcode.app`, because some Xcode frameworks need to be linked from the Xcode app itself.
 2. Clone this repo, build it, then restart Xcode.
 
 ### Or Use My Build
@@ -39,13 +39,13 @@ You can find XMate's actions under Xcode's **Edit** menu if it's loaded.
 
 All available actions are under Xcode's "Edit" menu. There aren't any keyboard shortcuts by default in case of conflicts. You can assign your favorite keyboard shortcuts in `System Preferences` -> `Keyboard`.
 
-![image](http://i.minus.com/imGDxlIUWBuCr.png)
+![image](http://shrani.si/f/1X/IM/4XjN1aFt/xmatekeyboardprefs.png)
 
 Here're all available actions, save you some typing.
-
-XMate:Select Scope  
-XMate:Select between Brackets  
-XMate:Ace Jump
+`XMate:Select Scope`
+`XMate:Select between Brackets`
+`XMate:Ace Jump`
+`XMate:Ace Jump Word`
 
 ### Selecting Actions
 
@@ -57,9 +57,9 @@ Select brackets action is similar to select scope action, but it will only exten
 
 ### Ace Jump
 
-1. Press the ace jump menu item or the hotkey you assigned, A little text field will pop up at the lower left corner of your current active editing area.
+1. Press the Ace Jump menu item or the hotkey you assigned. A little text field will pop up at the lower left corner of your current active editing area.
 
-2. Input the character you want to jump to (case sensitive, can be letters or symbols), all the same characters will be covered by a yellow label with a lowercased indicating letter.
+2. Input the character you want to jump to (case sensitive, can be letters or symbols), all the same characters will be covered by a yellow label with a lowercased indicating letter. In the word-mode, only words' first characters will be highlighted.
 
 3. Input the indicating letter, the caret will be moved to that location.
 
@@ -67,7 +67,7 @@ Select brackets action is similar to select scope action, but it will only exten
 
 5. Sometimes there're too many same characters on the screen, 26 letters are not enough to represent all of them, you can push `tab` or `return` to switch to next group.
 
-6. You can always push `esc` or the ace jump hotkey you assigned to quit ace jump mode.-
+6. You can always push `esc` or the Ace Jump hotkey you assigned to quit ace jump mode.
 
 ## XVim Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 XMate
 ==============
 
-TextMate and Emacs goodies for Xcode.
-
-
-## What is it?
-It's a Xcode plugin provides some handy TextMate and Emacs actions.
-
-###XMate actions in Edit menu:
+Plugin for Xcode that adds some handy TextMate and Emacs actions to the `Edit` menu. Works in Xcode 5.1 or above.
 
 ![image](http://shrani.si/f/1e/aO/YOG53s9/xmateeditmenu.png)
 
-###Emacs Ace Jump mode demo:
+##Demos
+
+###Select Scope:
+
+![image](http://shrani.si/f/3o/ay/2pXNSDZr/xmatescope.gif)
+
+###Ace Jump mode:
+![image](http://shrani.si/f/3I/uK/49yjQ1Av/acejumpchar.gif)
+
+###Ace Jump Word mode:
 
 ![image](http://shrani.si/f/2W/4x/111moo/xmateacejump.gif)
-
-## Requirement
-Xcode 5.1 or above
 
 ## Installation
 
@@ -29,15 +29,13 @@ Xcode 5.1 or above
 2. Unzip it, move `XMate.xcplugin` into `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins`.
 3. Restart Xcode.
 
-
-You can find XMate's actions under Xcode's **Edit** menu if it's loaded.
-
+You can find XMate's actions under Xcode's `Edit` menu if it's loaded.
 
 ## Usage
 
 ### Set Your Own Keyboard Shortcuts
 
-All available actions are under Xcode's "Edit" menu. There aren't any keyboard shortcuts by default in case of conflicts. You can assign your favorite keyboard shortcuts in `System Preferences` -> `Keyboard`.
+All available actions are under Xcode's `Edit` menu. There aren't any keyboard shortcuts by default in case of conflicts. You can assign your favorite keyboard shortcuts in `System Preferences` -> `Keyboard`.
 
 ![image](http://shrani.si/f/1X/IM/4XjN1aFt/xmatekeyboardprefs.png)
 
@@ -63,7 +61,7 @@ Select brackets action is similar to select scope action, but it will only exten
 
 5. Sometimes there're too many same characters on the screen, 26 letters are not enough to represent all of them, you can push `tab` or `return` to switch to next group.
 
-6. You can always push `esc` or the Ace Jump hotkey you assigned to quit ace jump mode.
+6. You can always push `esc` or the Ace Jump hotkey you assigned to quit Ace Jump mode.
 
 ## XVim Compatibility
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ All available actions are under Xcode's "Edit" menu. There aren't any keyboard s
 
 ![image](http://shrani.si/f/1X/IM/4XjN1aFt/xmatekeyboardprefs.png)
 
-Here're all available actions, save you some typing.
-`XMate:Select Scope`
-`XMate:Select between Brackets`
-`XMate:Ace Jump`
-`XMate:Ace Jump Word`
+Here're all available actions, to save you some typing: `XMate:Select Scope`, `XMate:Select between Brackets`, `XMate:Ace Jump`, `XMate:Ace Jump Word`.
 
 ### Selecting Actions
 

--- a/XMate.xcodeproj/project.pbxproj
+++ b/XMate.xcodeproj/project.pbxproj
@@ -334,7 +334,6 @@
 				CC76292917ACAE1400B16C79 /* Sources */,
 				CC76292A17ACAE1400B16C79 /* Frameworks */,
 				CC76292B17ACAE1400B16C79 /* Resources */,
-				F175B88552204D17B2FF66D3 /* Find unused imports */,
 			);
 			buildRules = (
 			);
@@ -370,7 +369,7 @@
 		CC76292517ACAE1400B16C79 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Indie Works";
 				TargetAttributes = {
 					CC8D161017AFADC400EFF3DE = {
@@ -415,23 +414,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		F175B88552204D17B2FF66D3 /* Find unused imports */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Find unused imports";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"/Users/pride/Library/Application Support/Developer/Shared/Xcode/Plug-ins/xcfui.xcplugin/Contents/Resources/fui_script.sh\" \"/Users/pride/Projects/Xcode Plugins/XMate\"";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		CC76292917ACAE1400B16C79 /* Sources */ = {

--- a/XMate.xcodeproj/project.pbxproj
+++ b/XMate.xcodeproj/project.pbxproj
@@ -144,7 +144,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CC33443D17E24F38005165AD /* IDEFoundation.framework in Frameworks */,
+				4D4F39921BC8021300B3BB2E /* IDEFoundation.framework in Frameworks */,
 				CC33443E17E24F38005165AD /* IDEKit.framework in Frameworks */,
 				CC33443F17E24F38005165AD /* DVTFoundation.framework in Frameworks */,
 				CC33444017E24F38005165AD /* DVTKit.framework in Frameworks */,
@@ -584,20 +584,15 @@
 					"$(inherited)",
 					$SRCROOT,
 					$SRCROOT/SharedFrameworks,
-					"$(SYSTEM_APPS_DIR)/Xcode5.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode5.app/Contents/SharedFrameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
 					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
 				);
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XMate/XMate-Prefix.pch";
 				INFOPLIST_FILE = "XMate/XMate-Info.plist";
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					/Users/pride/Projects/Xcode/XMate,
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xcplugin;
 			};
@@ -613,20 +608,15 @@
 					"$(inherited)",
 					$SRCROOT,
 					$SRCROOT/SharedFrameworks,
-					"$(SYSTEM_APPS_DIR)/Xcode5.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode5.app/Contents/SharedFrameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
 					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
 				);
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XMate/XMate-Prefix.pch";
 				INFOPLIST_FILE = "XMate/XMate-Info.plist";
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					/Users/pride/Projects/Xcode/XMate,
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xcplugin;
 			};
@@ -653,7 +643,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$SRCROOT/**",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/ParseKit-dedcuiziyyxdbifpdjamhgyubzhz/Build/Products/Debug",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "";
@@ -678,7 +667,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$SRCROOT/**",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/ParseKit-dedcuiziyyxdbifpdjamhgyubzhz/Build/Products/Debug",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "";

--- a/XMate/AceJump/IWAceJumpController.h
+++ b/XMate/AceJump/IWAceJumpController.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
+#import "NSString+Searching.h"
 
 @class DVTSourceTextView, IWAceJumpController, IWAceJumpTextField;
-
 
 
 @interface IWAceJumpController : NSObject
@@ -9,6 +9,6 @@
 @property (assign, nonatomic) DVTSourceTextView *sourceTextView;
 @property (strong, nonatomic) IWAceJumpTextField *textField;
 
-- (void)toggleAceJumpMode;
+- (void)toggleAceJumpMode:(IWAceJumpMode)mode;
 
 @end

--- a/XMate/AceJump/IWAceJumpController.m
+++ b/XMate/AceJump/IWAceJumpController.m
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSUInteger, IWAceJumpState) {
 @interface IWAceJumpController () <NSTextFieldDelegate>
 
 @property (nonatomic) IWAceJumpState state; // Indicates if ace jump mode is being active.
+@property (nonatomic) IWAceJumpMode aceJumpMode; // Indicates which ace jump mode is active.
 @property (strong, nonatomic) NSMutableArray *candidateLabels;
 
 @property (strong, nonatomic) NSArray *candidateRanges;
@@ -32,11 +33,11 @@ typedef NS_ENUM(NSUInteger, IWAceJumpState) {
     return self;
 }
 
-- (void)toggleAceJumpMode
+- (void)toggleAceJumpMode:(IWAceJumpMode)mode
 {
     if (self.state == IWAceJumpStateInactive) {
+        self.aceJumpMode = mode;
         [self enterAceJumpMode];
-        
     } else {
         [self quitAceJumpMode];
     }
@@ -138,7 +139,9 @@ typedef NS_ENUM(NSUInteger, IWAceJumpState) {
     self.candidateOffset = 0;
     NSString *character = [[self.textField stringValue] substringWithRange:NSMakeRange(0, 1)];
     self.candidateRanges = [[[self.sourceTextView textStorage] string] rangesOfCharacter:character
-                                                                                   range:[self visibleTextRangeInSourceTextView]];
+                                                                                   range:[self visibleTextRangeInSourceTextView]
+                                                                                    mode:self.aceJumpMode];
+    
     [self nextCandidateBatch];
 }
 

--- a/XMate/Helpers/NSString+Searching.h
+++ b/XMate/Helpers/NSString+Searching.h
@@ -1,10 +1,16 @@
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, IWAceJumpMode) {
+    IWAceJumpModeCharacter,
+    IWAceJumpModeWord,
+};
+
+
 @interface NSString (Searching)
 
 - (BOOL)contains:(NSString *)string; // Returns if a string contains another string
 
-// Returns all occurrences of the given string in receiver, within given search range.
-- (NSArray *)rangesOfCharacter:(NSString *)character range:(NSRange)searchRange;
+// Returns all occurrences of the given character in receiver, within given search range and according to jump mode.
+- (NSArray *)rangesOfCharacter:(NSString *)character range:(NSRange)searchRange mode:(IWAceJumpMode)mode;
 
 @end

--- a/XMate/Helpers/NSString+Searching.m
+++ b/XMate/Helpers/NSString+Searching.m
@@ -7,18 +7,39 @@
     return [self rangeOfString:string].location != NSNotFound;
 }
 
-- (NSArray *)rangesOfCharacter:(NSString *)character range:(NSRange)searchRange
+- (NSArray *)rangesOfCharacter:(NSString *)character range:(NSRange)searchRange mode:(IWAceJumpMode)mode
 {
     NSMutableArray *ranges = [NSMutableArray array];
     
     [self enumerateSubstringsInRange:searchRange
-                             options:NSStringEnumerationByComposedCharacterSequences
+                             options:(mode == IWAceJumpModeCharacter ? NSStringEnumerationByComposedCharacterSequences : NSStringEnumerationByWords)
                           usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
-                              if ([substring isEqualToString:character]) {
-                                  [ranges addObject:[NSValue valueWithRange:substringRange]];
+                              if (mode == IWAceJumpModeCharacter)
+                              {
+                                  if ([substring isEqualToString:character]) {
+                                      [ranges addObject:[NSValue valueWithRange:substringRange]];
+                                  }
+                              }
+                              else if (mode == IWAceJumpModeWord)
+                              {
+                                  // Given "self.property" one should be able to jump to both "self" and "property".
+                                  NSCharacterSet *set = [NSCharacterSet characterSetWithCharactersInString:@".:{}"];
+                                  NSArray *components = [substring componentsSeparatedByCharactersInSet:set];
+                                  NSUInteger wordLocationInContainer = 0;
+                                  for (NSString *word in components)
+                                  {
+                                      NSString *firstCharacter = [word substringWithRange:(NSRange){0,1}];
+                                      if ([firstCharacter isEqualToString:character]) {
+                                          [ranges addObject:[NSValue valueWithRange:NSMakeRange(substringRange.location + wordLocationInContainer, 1)]];
+                                      }
+                                      
+                                      // Next word will be upstream of current word's length and separator.
+                                      wordLocationInContainer += word.length + 1;
+                                  }
                               }
                           }];
     
     return [ranges copy];
 }
+
 @end

--- a/XMate/IWSourceEditorController.h
+++ b/XMate/IWSourceEditorController.h
@@ -4,6 +4,7 @@
 
 - (void)selectScopeDidTrigger;
 - (void)selectBracketDidTrigger;
-- (void)aceJumpDidTrigger;
+- (void)aceJumpCharDidTrigger;
+- (void)aceJumpWordDidTrigger;
 
 @end

--- a/XMate/IWSourceEditorController.m
+++ b/XMate/IWSourceEditorController.m
@@ -82,14 +82,24 @@
     [selectAction selectPairedBrackets];
 }
 
-- (void)aceJumpDidTrigger
+- (void)aceJumpDidTrigger:(IWAceJumpMode)mode
 {
     if ([self.activeEditor isKindOfClass:[DVTSourceTextView class]]) {
         if (!self.activeEditor.aceJumpController.sourceTextView) {
             self.activeEditor.aceJumpController.sourceTextView = self.activeEditor;
         }
-        [self.activeEditor.aceJumpController toggleAceJumpMode];
+        [self.activeEditor.aceJumpController toggleAceJumpMode:mode];
     }
+}
+
+- (void)aceJumpCharDidTrigger
+{
+    [self aceJumpDidTrigger:IWAceJumpModeCharacter];
+}
+
+- (void)aceJumpWordDidTrigger
+{
+    [self aceJumpDidTrigger:IWAceJumpModeWord];
 }
 
 - (DVTSourceTextView *)sourceTextViewEditorContext:(IDEEditorContext *)context

--- a/XMate/SelectAction/IWSelectAction.m
+++ b/XMate/SelectAction/IWSelectAction.m
@@ -39,14 +39,6 @@
 #endif
         return;
     }
-    
-    if (![[self.editor selectedRanges] count] > 1) {
-        // Don't handle multi selection
-#if DEBUG_SELECTION
-        NSLog(@"Multiple selection.");
-#endif
-        return;
-    }
 
     NSRange selectedRange = [self.editor selectedRange];
     NSString *editorText = [[self.editor textStorage] string];

--- a/XMate/XMate-Info.plist
+++ b/XMate/XMate-Info.plist
@@ -24,8 +24,11 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>

--- a/XMate/XMate.h
+++ b/XMate/XMate.h
@@ -5,5 +5,6 @@
 @property (strong, nonatomic) NSMenuItem *selectScopeMenuItem;
 @property (strong, nonatomic) NSMenuItem *selectBracketMenuItem;
 @property (strong, nonatomic) NSMenuItem *aceJumpMenuItem;
+@property (strong, nonatomic) NSMenuItem *aceJumpWordMenuItem;
 
 @end

--- a/XMate/XMate.m
+++ b/XMate/XMate.m
@@ -63,15 +63,21 @@ static XMate *mate;
                                                          keyEquivalent:@""];
         
         self.aceJumpMenuItem = [[NSMenuItem alloc] initWithTitle:@"XMate:Ace Jump"
-                                                                action:@selector(aceJumpDidTrigger)
-                                                         keyEquivalent:@""];
-
+                                                          action:@selector(aceJumpCharDidTrigger)
+                                                   keyEquivalent:@""];
+        
+        self.aceJumpWordMenuItem = [[NSMenuItem alloc] initWithTitle:@"XMate:Ace Jump Word"
+                                                              action:@selector(aceJumpWordDidTrigger)
+                                                       keyEquivalent:@""];
+        
         [self.selectScopeMenuItem setTarget:self.editorController];
         [self.selectBracketMenuItem setTarget:self.editorController];
         [self.aceJumpMenuItem setTarget:self.editorController];
+        [self.aceJumpWordMenuItem setTarget:self.editorController];
         [[editMenuItem submenu] addItem:self.selectScopeMenuItem];
         [[editMenuItem submenu] addItem:self.selectBracketMenuItem];
         [[editMenuItem submenu] addItem:self.aceJumpMenuItem];
+        [[editMenuItem submenu] addItem:self.aceJumpWordMenuItem];
     }
 }
 

--- a/XMateTests/IWBracketSearcherTests.m
+++ b/XMateTests/IWBracketSearcherTests.m
@@ -96,7 +96,7 @@
     IWBracketSearcher *searcher = [[IWBracketSearcher alloc] initWithTokens:self.mockTokens1
                                                               selectedRange:NSMakeRange(1, 0)];
     IWOpenBracketSearchResult *result = [searcher searchForOpenBracketBeforeCaret];
-    XCTAssertEqual(result.range, NSMakeRange(0, 1));
+    XCTAssertTrue(NSEqualRanges(result.range, NSMakeRange(0, 1)));
     XCTAssertEqualObjects(result.openBracketChar, @"{");
     XCTAssertEqualObjects(result.closingBracketChar, @"}");
     
@@ -104,7 +104,7 @@
     searcher = [[IWBracketSearcher alloc] initWithTokens:self.mockTokens2
                                         selectedRange:NSMakeRange(6, 0)];
     result = [searcher searchForOpenBracketBeforeCaret];
-    XCTAssertEqual(result.range, NSMakeRange(2, 1));
+    XCTAssertTrue(NSEqualRanges(result.range, NSMakeRange(2, 1)));
     XCTAssertEqualObjects(result.openBracketChar, @"[");
     XCTAssertEqualObjects(result.closingBracketChar, @"]");
 }
@@ -120,9 +120,9 @@
                                                           selectedRange:NSMakeRange(NSNotFound, 0)];
     
 
-    XCTAssertEqual([searcher rangeForClosingBracket:@"}"
-                                usingOpenBracket:@"{"
-                                 searchingOffset:0], NSMakeRange(2, 1));
+    XCTAssertTrue(NSEqualRanges([searcher rangeForClosingBracket:@"}"
+                                                usingOpenBracket:@"{"
+                                                 searchingOffset:0], NSMakeRange(2, 1)));
     
    /* Mock tokens should looks like this, caret means searching offset :
     0 1 2 3 4 5 6 7 8 9
@@ -131,9 +131,9 @@
     */
     searcher = [[IWBracketSearcher alloc] initWithTokens:self.mockTokens2
                                         selectedRange:NSMakeRange(NSNotFound, 0)];
-    XCTAssertEqual([searcher rangeForClosingBracket:@"]"
-                                 usingOpenBracket:@"["
-                                  searchingOffset:2], NSMakeRange(7, 1));
+    XCTAssertTrue(NSEqualRanges([searcher rangeForClosingBracket:@"]"
+                                                usingOpenBracket:@"["
+                                                 searchingOffset:2], NSMakeRange(7, 1)));
 }
 
 @end

--- a/XMateTests/NSStringSearchingTests.m
+++ b/XMateTests/NSStringSearchingTests.m
@@ -3,6 +3,8 @@
 
 @interface NSStringSearchingTests : XCTestCase
 
+@property (nonatomic) IWAceJumpMode mode;
+
 @end
 
 @implementation NSStringSearchingTests
@@ -21,23 +23,48 @@
 
 - (void)testRangesOfStringInRange
 {
+    self.mode = IWAceJumpModeCharacter;
+    
     //              0123456789
     NSString *s = @"foo*bar.fo";
-    NSArray *ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(0, [s length])];
+    NSArray *ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(0, [s length]) mode:self.mode];
     XCTAssertEqual([ranges count], 2ul);
-    XCTAssertEqual([ranges[0] rangeValue], NSMakeRange(0, 1));
-    XCTAssertEqual([ranges[1] rangeValue], NSMakeRange(8, 1));
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(0, 1)));
+    XCTAssertTrue(NSEqualRanges([ranges[1] rangeValue], NSMakeRange(8, 1)));
     
-    ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(1, [s length] - 1)];
+    ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
     XCTAssertEqual([ranges count], 1ul);
-    XCTAssertEqual([ranges[0] rangeValue], NSMakeRange(8, 1));
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(8, 1)));
     
-    ranges = [s rangesOfCharacter:@"*" range:NSMakeRange(1, [s length] - 1)];
+    ranges = [s rangesOfCharacter:@"*" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
     XCTAssertEqual([ranges count], 1ul);
-    XCTAssertEqual([ranges[0] rangeValue], NSMakeRange(3, 1));
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(3, 1)));
     
-    ranges = [s rangesOfCharacter:@"." range:NSMakeRange(1, [s length] - 1)];
+    ranges = [s rangesOfCharacter:@"." range:NSMakeRange(1, [s length] - 1) mode:self.mode];
     XCTAssertEqual([ranges count], 1ul);
-    XCTAssertEqual([ranges[0] rangeValue], NSMakeRange(7, 1));
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(7, 1)));
+}
+
+- (void)testRangesOfFirstWordCharacterInRange
+{
+    self.mode = IWAceJumpModeWord;
+    
+    NSString *s = @"[self.textField setStringValue:[[self.textField stringValue] substringToIndex:1]];";
+    
+    NSArray *ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(0, [s length]) mode:self.mode];
+    XCTAssertEqual([ranges count], 0ul);
+    
+    ranges = [s rangesOfCharacter:@"1" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    XCTAssertEqual([ranges count], 1ul);
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(s.length-4, 1)));
+    
+    ranges = [s rangesOfCharacter:@"t" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    XCTAssertEqual([ranges count], 2ul);
+    XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(6, 1)));
+    XCTAssertTrue(NSEqualRanges([ranges[1] rangeValue], NSMakeRange(38, 1)));
+    
+    ranges = [s rangesOfCharacter:@"s" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    XCTAssertEqual([ranges count], 5ul);
+    XCTAssertTrue(NSEqualRanges([ranges[2] rangeValue], NSMakeRange(33, 1)));
 }
 @end

--- a/XMateTests/NSStringSearchingTests.m
+++ b/XMateTests/NSStringSearchingTests.m
@@ -50,20 +50,21 @@
     self.mode = IWAceJumpModeWord;
     
     NSString *s = @"[self.textField setStringValue:[[self.textField stringValue] substringToIndex:1]];";
+    NSRange range = NSMakeRange(0, [s length] - 1);
     
-    NSArray *ranges = [s rangesOfCharacter:@"f" range:NSMakeRange(0, [s length]) mode:self.mode];
+    NSArray *ranges = [s rangesOfCharacter:@"f" range:range mode:self.mode];
     XCTAssertEqual([ranges count], 0ul);
     
-    ranges = [s rangesOfCharacter:@"1" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    ranges = [s rangesOfCharacter:@"1" range:range mode:self.mode];
     XCTAssertEqual([ranges count], 1ul);
     XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(s.length-4, 1)));
     
-    ranges = [s rangesOfCharacter:@"t" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    ranges = [s rangesOfCharacter:@"t" range:range mode:self.mode];
     XCTAssertEqual([ranges count], 2ul);
     XCTAssertTrue(NSEqualRanges([ranges[0] rangeValue], NSMakeRange(6, 1)));
     XCTAssertTrue(NSEqualRanges([ranges[1] rangeValue], NSMakeRange(38, 1)));
     
-    ranges = [s rangesOfCharacter:@"s" range:NSMakeRange(1, [s length] - 1) mode:self.mode];
+    ranges = [s rangesOfCharacter:@"s" range:range mode:self.mode];
     XCTAssertEqual([ranges count], 5ul);
     XCTAssertTrue(NSEqualRanges([ranges[2] rangeValue], NSMakeRange(33, 1)));
 }


### PR DESCRIPTION
Hi Pride, I've made these changes, hopefully for the better:
1. First and foremost, a new `Ace Jump Word` mode that lets user jump on words' first character. The old `Ace Jump` mode was left untouched, including its title in the `Edit` menu (so as not to break existing keyboard shortcuts).
2. Made the test target build again. And also added a rudimentary test for the new `Word` mode.
3. Fixed some Xcode warnings, mainly to do with machine-specific search paths.
4. Updated the README with some demos and other minor formatting.

Should you accept the pull request, you might want to update the `.zip` file (linked to in the `Or Use My Build` section of README) with a new version.
